### PR TITLE
Fix package metadata

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,18 +30,19 @@ requirements:
     - python >=3.7
 
 test:
+  requires:
+    - pip
+    - pytest
   imports:
     - gcn
     - gcn.handlers
     - gcn.notice_types
     - gcn.voeventclient
-  requires:
-    - setuptools  # for pkg_resources
-    - pytest
   commands:
+    - python -m pip check
+    - python -m pytest --pyargs gcn
     - pygcn-listen --help
     - pygcn-serve --help
-    - python -m pytest --pyargs gcn
 
 about:
   home: https://github.com/lpsinger/pygcn

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vvv
   entry_points:
@@ -20,12 +20,14 @@ build:
 
 requirements:
   host:
-    - python >=3.7
     - pip
-    - setuptools >=30.3.0
-  run:
     - python >=3.7
+    - setuptools >=42
+    - setuptools-scm >=3.4
+    - wheel
+  run:
     - lxml
+    - python >=3.7
 
 test:
   imports:


### PR DESCRIPTION
This PR fixes the metadata for 1.1.2, principally by adding the missing `setuptools-scm` version requirement.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
